### PR TITLE
Added a check for stable charts that use incubator charts

### DIFF
--- a/src/main/java/org/alfresco/deployment/util/ChartMap.java
+++ b/src/main/java/org/alfresco/deployment/util/ChartMap.java
@@ -1289,9 +1289,15 @@ public class ChartMap {
             }
             if (parent.getDependencies() != null) {
                 // Print the chart to chart dependencies recursively
+                boolean stable=isStable(parent);
                 for (HelmChart dependent : parent.getDependencies()) {
                     if (!chartsDependenciesPrinted.contains(parent.getNameFull() + "_" + dependent.getNameFull())) {
                         printer.printChartToChartDependency(parent, dependent);
+                        if (stable) { // if the parent is stable and the child is not then print a message if verbose
+                            if (!isStable(dependent) && isVerbose()) {
+                                System.out.println("Chart " + parent.getNameFull() + " is stable but depends on " + dependent.getNameFull() + " which may not be stable");
+                            }
+                        }
                         chartsDependenciesPrinted.add(parent.getNameFull() + "_" + dependent.getNameFull());
                     }
                     printChartDependencies(dependent);   // recursion
@@ -1350,6 +1356,17 @@ public class ChartMap {
         } else {
             printFormat = PrintFormat.TEXT;
         }
+    }
+
+    /**
+     * Determines whether a Helm Chart is stable based on a very
+     * simple heuristic.
+     *
+     * @param chart the Helm Chart to be inspected
+     */
+    private boolean isStable(HelmChart chart) {
+        if (!chart.getRepoUrl().contains("/incubator")) return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
When such a chart is found and the verbose flag is set, then a message is emitted like these examples ...

> Chart alfresco-process-infrastructure:7.1.0-M4 is stable but depends on alfresco-infrastructure:5.1.1 which may not be stable
> Chart alfresco-process-infrastructure:7.1.0-M4 is stable but depends on alfresco-process-springboot-service:2.1.0 which may not be stable

